### PR TITLE
Change proportionOf property from String to Integer type

### DIFF
--- a/src/spatialcubeservice/src/main/java/org/vpac/web/model/TableBuilder.java
+++ b/src/spatialcubeservice/src/main/java/org/vpac/web/model/TableBuilder.java
@@ -113,7 +113,7 @@ public class TableBuilder {
 				.description("The category of the data."));
 		columns.add(new TableColumn()
 				.key(1).name("Area").units("m^2").type("area")
-				.portionOf("rawArea")
+				.portionOf(2)
 				.description("The area of land that matches the filters."));
 		columns.add(new TableColumn()
 				.key(2).name("Unfiltered Area").units("m^2").type("area")
@@ -176,7 +176,7 @@ public class TableBuilder {
 				.description("The upper bound of the grouping (value range)."));
 		columns.add(new TableColumn()
 				.key(2).name("Area").units("m^2").type("area")
-				.portionOf("rawArea")
+				.portionOf(3)
 				.description("The area of land that matches the filters."));
 		columns.add(new TableColumn()
 				.key(3).name("Unfiltered Area").units("m^2")
@@ -218,7 +218,7 @@ public class TableBuilder {
 		}
 		columns.add(new TableColumn()
 				.key(i++).name("Area").units("m^2").type("area")
-				.portionOf("rawArea")
+				.portionOf(i+1)
 				.description("The area of land that matches the filters."));
 		columns.add(new TableColumn()
 				.key(i++).name("Unfiltered Area").units("m^2")

--- a/src/spatialcubeservice/src/main/java/org/vpac/web/model/response/TableColumn.java
+++ b/src/spatialcubeservice/src/main/java/org/vpac/web/model/response/TableColumn.java
@@ -10,7 +10,7 @@ public class TableColumn {
 	private String description;
 	private String units;
 	private String type;
-	private String portionOf;
+	private Integer portionOf;
 	private Double min;
 	private Double max;
 
@@ -78,13 +78,13 @@ public class TableColumn {
 	}
 
 	@XmlAttribute
-	public String getPortionOf() {
+	public Integer getPortionOf() {
 		return portionOf;
 	}
-	public void setPortionOf(String portionOf) {
+	public void setPortionOf(Integer portionOf) {
 		this.portionOf = portionOf;
 	}
-	public TableColumn portionOf(String portionOf) {
+	public TableColumn portionOf(Integer portionOf) {
 		this.portionOf = portionOf;
 		return this;
 	}


### PR DESCRIPTION
I'm fairly sure we need to do something like this. Formerly the proportionOf string would refer to one of the field names in the `rows` data, but we no longer have field names there.

Now I'm suggesting the proportionOf should refer to the `key` of the column it relates too.
