### PR TITLE
Map tile generation now reports accurate progress

### DIFF
--- a/src/spatialcubeservice/src/main/java/org/vpac/web/servlets/TmsServlet.java
+++ b/src/spatialcubeservice/src/main/java/org/vpac/web/servlets/TmsServlet.java
@@ -29,7 +29,6 @@ import org.vpac.ndg.storage.model.Dataset;
 import org.vpac.ndg.storage.model.JobProgress;
 import org.vpac.ndg.storage.model.TimeSlice;
 import org.vpac.ndg.storage.util.DatasetUtil;
-import org.vpac.ndg.task.Task;
 import org.vpac.ndg.task.WmtsBandCreator;
 import org.vpac.ndg.task.WmtsQueryCreator;
 
@@ -42,9 +41,9 @@ public class TmsServlet extends HttpServlet {
     private TimeSliceDao timeSliceDao;
     private JobProgressDao jobProgressDao;
     private NdgConfigManager ndgConfigManager;
-    
+
     private DatasetUtil datasetUtil;
-    
+
     @Override
     public void init(ServletConfig config) throws ServletException {
         super.init(config);
@@ -56,7 +55,7 @@ public class TmsServlet extends HttpServlet {
         this.timeSliceDao = (TimeSliceDao) ctx.getBean("timeSliceDao");
         this.jobProgressDao = (JobProgressDao) ctx.getBean("jobProgressDao");
         this.ndgConfigManager = (NdgConfigManager) ctx.getBean("ndgConfigManager");
-        
+
         datasetUtil = new DatasetUtil();
     }
 
@@ -68,8 +67,8 @@ public class TmsServlet extends HttpServlet {
         }
         return null;
     }
-    
-    
+
+
     public void doGet(HttpServletRequest request, HttpServletResponse response)
             throws ServletException, IOException {
 
@@ -130,7 +129,7 @@ public class TmsServlet extends HttpServlet {
             doGetDataset(dataset, timesliceId, bandId, urlRemainder, request, response);
             return;
         }
-        
+
         //If we've made it this far then either the dataset or progress Id just doesn't exist
         response.setContentType("text/html");
         response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
@@ -143,11 +142,11 @@ public class TmsServlet extends HttpServlet {
             throws ServletException, IOException {
         Path datasetDir = datasetUtil.getPath(dataset);
         Path wmtsDir = datasetDir.resolve(WmtsBandCreator.WMTS_TILE_DIR);
-        
+
         String tsAndBandPath = String.format("%s/%s/%s", timesliceId, bandId, urlRemainder);
-        
+
         Path resolvedWmtsTileFile = wmtsDir.resolve(tsAndBandPath);
-        
+
         if (Files.notExists(resolvedWmtsTileFile)) {
             response.setContentType("text/html");
             response.setStatus(HttpServletResponse.SC_NOT_FOUND);
@@ -155,7 +154,7 @@ public class TmsServlet extends HttpServlet {
             out.println("No tile");
         }
         else {
-            writeFileToResponse(resolvedWmtsTileFile, response);   
+            writeFileToResponse(resolvedWmtsTileFile, response);
         }
     }
 
@@ -184,20 +183,20 @@ public class TmsServlet extends HttpServlet {
 
     protected Path getQueryWmtsDirectory(String queryJobProgressId) {
         Path pickupPath = Paths.get(ndgConfigManager.getConfig().getDefaultPickupLocation());
-        
+
         String wmtsPath = String.format("%s/%s/%s", queryJobProgressId, WmtsQueryCreator.WMTS_TILE_DIR, queryJobProgressId);
         Path queryPickupPath = pickupPath.resolve(wmtsPath);
-        
+
         return queryPickupPath;
     }
-    
+
     private void doGetQuery(JobProgress progress, String urlRemainder, HttpServletRequest request, HttpServletResponse response)
             throws ServletException, IOException {
-        
+
         Path queryWmtsDir = getQueryWmtsDirectory(progress.getId());
-        
+
         Path resolvedWmtsTileFile = queryWmtsDir.resolve(urlRemainder.substring(1));
-        
+
         if (Files.notExists(resolvedWmtsTileFile)) {
             response.setContentType("text/html");
             response.setStatus(HttpServletResponse.SC_NOT_FOUND);
@@ -205,7 +204,7 @@ public class TmsServlet extends HttpServlet {
             out.println("No tile");
         }
         else {
-            writeFileToResponse(resolvedWmtsTileFile, response);   
+            writeFileToResponse(resolvedWmtsTileFile, response);
         }
     }
 

--- a/src/storagemanager/src/main/java/org/vpac/ndg/task/BaseTask.java
+++ b/src/storagemanager/src/main/java/org/vpac/ndg/task/BaseTask.java
@@ -28,7 +28,7 @@ import org.vpac.ndg.exceptions.TaskException;
  * @author hsumanto
  *
  */
-public abstract class BaseTask implements ITask {
+public abstract class BaseTask implements Task {
 	/** Task description */
 	private String description;
 	/** Job progress on the task */
@@ -55,7 +55,7 @@ public abstract class BaseTask implements ITask {
 	}
 
 	public void execute(Collection<String> actionLog) throws TaskException {
-		//implemented to maintain compatibility with previous ITask interface
+		//implemented to maintain compatibility with previous Task interface
 		this.execute(actionLog, null);
 	}
 

--- a/src/storagemanager/src/main/java/org/vpac/ndg/task/BaseTask.java
+++ b/src/storagemanager/src/main/java/org/vpac/ndg/task/BaseTask.java
@@ -28,7 +28,7 @@ import org.vpac.ndg.exceptions.TaskException;
  * @author hsumanto
  *
  */
-public abstract class Task implements ITask {
+public abstract class BaseTask implements ITask {
 	/** Task description */
 	private String description;
 	/** Job progress on the task */
@@ -45,7 +45,7 @@ public abstract class Task implements ITask {
 	 * Construct a task using the specified description.
 	 * @param description The given task description.
 	 */
-	public Task(String description) {
+	public BaseTask(String description) {
 		setDescription(description);
 		// By default clean up source and target
 		setCleanupSource(true);

--- a/src/storagemanager/src/main/java/org/vpac/ndg/task/Committer.java
+++ b/src/storagemanager/src/main/java/org/vpac/ndg/task/Committer.java
@@ -52,7 +52,7 @@ import org.vpac.ndg.storage.util.TimeSliceUtil;
  * @author hsumanto
  *
  */
-public class Committer extends Task {
+public class Committer extends BaseTask {
 
 	final Logger log = LoggerFactory.getLogger(Committer.class);
 

--- a/src/storagemanager/src/main/java/org/vpac/ndg/task/Committer.java
+++ b/src/storagemanager/src/main/java/org/vpac/ndg/task/Committer.java
@@ -103,7 +103,7 @@ public class Committer extends BaseTask {
 	// FIXME: This is not actually transactional because this class is not a spring bean!
 	@Transactional
 	@Override
-	public void execute(Collection<String> actionLog, IProgressCallback progressCallback) throws TaskException {
+	public void execute(Collection<String> actionLog, ProgressCallback progressCallback) throws TaskException {
 		log.debug("TASK = {}", getDescription());
 
 		// If nothing to commit then do nothing

--- a/src/storagemanager/src/main/java/org/vpac/ndg/task/Committer.java
+++ b/src/storagemanager/src/main/java/org/vpac/ndg/task/Committer.java
@@ -48,7 +48,7 @@ import org.vpac.ndg.storage.util.TimeSliceUtil;
  * This class is responsible for copy the tile from their temporary storage into
  * the storage pool. Once all tiles have been successfully moved into storage pool
  * then save them into database and increase upload counter for TimeSlice.
- * 
+ *
  * @author hsumanto
  *
  */
@@ -103,7 +103,7 @@ public class Committer extends Task {
 	// FIXME: This is not actually transactional because this class is not a spring bean!
 	@Transactional
 	@Override
-	public void execute(Collection<String> actionLog) throws TaskException {
+	public void execute(Collection<String> actionLog, IProgressCallback progressCallback) throws TaskException {
 		log.debug("TASK = {}", getDescription());
 
 		// If nothing to commit then do nothing
@@ -113,13 +113,13 @@ public class Committer extends Task {
 
 		actionLog.add("Renaming tiles");
 		for(TileBand tileband: source) {
-			log.debug("SOURCE = {}", tileband.getFileLocation());	
+			log.debug("SOURCE = {}", tileband.getFileLocation());
 			// Rename an existing tileband by adding .old extension into the tileband name.
 			tileband.renameExistingTileAsOld();
 			// Copy the tileband into its default location in storagepool.
-			tileband.copyIntoDefaultLocationInStoragePool();		
+			tileband.copyIntoDefaultLocationInStoragePool();
 			// Add tileband into tile list if it doesn't exist in this time slice
-			log.debug("TARGET = {}", tileband.getFileLocation());						
+			log.debug("TARGET = {}", tileband.getFileLocation());
 			log.info("Committing {} tile = {}", tileband.getBand().getName(),
 					tileband.getTileNameWithExtention());
 		}
@@ -147,7 +147,7 @@ public class Committer extends Task {
 		} catch (IOException e) {
 			throw new TaskException(e);
 		}
-		
+
 		if (band.getNodata() == null || band.getType() == null) {
 			if (band.getNodata() != null) {
 				if (!band.getNodata().equals(dstnodata))
@@ -160,7 +160,7 @@ public class Committer extends Task {
 					throw new TaskException("Can't change band's type.");
 			}
 			band.setType(datatype);
-			
+
 			try {
 				bandUtil.createBlankTile(dataset, band);
 			} catch (IOException e) {
@@ -184,7 +184,7 @@ public class Committer extends Task {
 		if(source == null) {
 			return;
 		}
-		
+
 		// Move back to old location
 		for(TileBand tileband: source) {
 			try {
@@ -202,7 +202,7 @@ public class Committer extends Task {
 		if(source == null) {
 			return;
 		}
-		
+
 		// Delete old tiles
 		for(TileBand tileband: source) {
 			tileband.deleteTileInPreviousStorage();
@@ -220,7 +220,7 @@ public class Committer extends Task {
 	public void setTarget(TimeSlice target) {
 		this.target = target;
 	}
-	
+
 	public TimeSlice getTarget() {
 		return target;
 	}

--- a/src/storagemanager/src/main/java/org/vpac/ndg/task/Compressor.java
+++ b/src/storagemanager/src/main/java/org/vpac/ndg/task/Compressor.java
@@ -65,7 +65,7 @@ public class Compressor extends Task {
 	}
 
 	@Override
-	public void execute(Collection<String> actionLog) throws TaskException {
+	public void execute(Collection<String> actionLog, IProgressCallback progressCallback) throws TaskException {
 		// Collate all source files.
 		List<Path> paths = new ArrayList<>();
 		for (List<GraphicsFile> gs : sourceGraphicsFiles) {
@@ -75,7 +75,7 @@ public class Compressor extends Task {
 					log.info("Non-existent file excluded from compression process:\n{}", g.getFileLocation());
 					continue;
 				}
-				
+
 				paths.add(g.getFileLocation());
 			}
 		}

--- a/src/storagemanager/src/main/java/org/vpac/ndg/task/Compressor.java
+++ b/src/storagemanager/src/main/java/org/vpac/ndg/task/Compressor.java
@@ -40,7 +40,7 @@ import org.vpac.ndg.exceptions.TaskException;
 import org.vpac.ndg.exceptions.TaskInitialisationException;
 import org.vpac.ndg.storagemanager.GraphicsFile;
 
-public class Compressor extends Task {
+public class Compressor extends BaseTask {
 
 	final Logger log = LoggerFactory.getLogger(Compressor.class);
 

--- a/src/storagemanager/src/main/java/org/vpac/ndg/task/Compressor.java
+++ b/src/storagemanager/src/main/java/org/vpac/ndg/task/Compressor.java
@@ -65,7 +65,7 @@ public class Compressor extends BaseTask {
 	}
 
 	@Override
-	public void execute(Collection<String> actionLog, IProgressCallback progressCallback) throws TaskException {
+	public void execute(Collection<String> actionLog, ProgressCallback progressCallback) throws TaskException {
 		// Collate all source files.
 		List<Path> paths = new ArrayList<>();
 		for (List<GraphicsFile> gs : sourceGraphicsFiles) {

--- a/src/storagemanager/src/main/java/org/vpac/ndg/task/FileStatistics.java
+++ b/src/storagemanager/src/main/java/org/vpac/ndg/task/FileStatistics.java
@@ -33,10 +33,10 @@ public class FileStatistics extends Task {
     private final String COMPUTED_MINMAX = "Computed Min/Max";
     private final String PIXEL_TYPE = "PIXELTYPE";
     private final String NO_DATA = "NoData Value";
-    
+
     private GraphicsFile source;
     private boolean approximate;
-    
+
     //the gathered stats
     private ScalarReceiver<Double> max;
     private ScalarReceiver<Double> min;
@@ -45,12 +45,12 @@ public class FileStatistics extends Task {
     private ScalarReceiver<Double> nodata;
     private ScalarReceiver<String> pixelType;
 
-    
-    
+
+
     public FileStatistics() {
         this("Extracting file statistics");
     }
-    
+
     public FileStatistics(String description) {
         super(description);
     }
@@ -72,38 +72,38 @@ public class FileStatistics extends Task {
 
         command.add("-noct");
         // command.add("-mm");
-        
+
         if (approximate) {
             command.add("-approx_stats");
         } else {
             command.add("-stats");
         }
-        
+
         command.add(source.getFileLocation().toString());
         log.info("command:" + command);
         return command;
     }
 
-    
-    
+
+
     @Override
-    public void execute(Collection<String> actionLog) throws TaskException {
+    public void execute(Collection<String> actionLog, IProgressCallback progressCallback) throws TaskException {
         List<String> command = prepareCommand();
-        
+
         String listString = "";
         for (String s : command) {
             listString += s + " ";
         }
         log.info(listString);
-        
+
         String stdout = "";
         try {
-            
+
             //in this case we dont use the command util as we care about the stdout stuff
             actionLog.add(StringUtils.join(command, " "));
             ProcessBuilder pb = new ProcessBuilder(command);
             Process process = pb.start();
-            
+
             BufferedReader br = new BufferedReader(new InputStreamReader(process.getInputStream()));
             StringBuilder builder = new StringBuilder();
             String line = null;
@@ -125,9 +125,9 @@ public class FileStatistics extends Task {
            STATISTICS_MINIMUM=300
            STATISTICS_STDDEV=23.6484643221
          */
-        
+
         int foundCount = 0;
-        
+
         //Read the info we're after and put it in some scalar receivers
         String lines[] = stdout.split(System.lineSeparator());
         for (String line: lines) {
@@ -136,7 +136,7 @@ public class FileStatistics extends Task {
                 getMax().set(getStatsValue(line));
                 log.info("Found max of " + getMax().get().toString());
                 foundCount++;
-            } else 
+            } else
             if (line.startsWith(STATS_MEAN)) {
                 getMean().set(getStatsValue(line));
                 log.info("Found mean of " + getMean().get().toString());
@@ -161,12 +161,12 @@ public class FileStatistics extends Task {
 
             // } else if (line.startsWith(COMPUTED_MINMAX)) {
             //     setComputedValues(line);
-            //     log.info("Computed Min and Max of " + getMin().get().toString() 
+            //     log.info("Computed Min and Max of " + getMin().get().toString()
             //         + "," + getMax().get().toString());
             //     foundCount += 2;
             }
         }
-        
+
         if (foundCount < 4) {
             StringBuilder sb = new StringBuilder();
             int start = lines.length - 11;
@@ -192,7 +192,7 @@ public class FileStatistics extends Task {
         String numberBit = line.substring(line.indexOf('=')+1);
         return Double.parseDouble(numberBit);
     }
-    
+
     private void setComputedValues(String line) {
         String minAndMax = line.substring(line.indexOf('=')+1);
         Double min = Double.parseDouble(minAndMax.split(",")[0]);

--- a/src/storagemanager/src/main/java/org/vpac/ndg/task/FileStatistics.java
+++ b/src/storagemanager/src/main/java/org/vpac/ndg/task/FileStatistics.java
@@ -21,7 +21,7 @@ import org.vpac.ndg.storagemanager.GraphicsFile;
  * @author lachlan
  *
  */
-public class FileStatistics extends Task {
+public class FileStatistics extends BaseTask {
 
     final private Logger log = LoggerFactory.getLogger(FileStatistics.class);
 

--- a/src/storagemanager/src/main/java/org/vpac/ndg/task/FileStatistics.java
+++ b/src/storagemanager/src/main/java/org/vpac/ndg/task/FileStatistics.java
@@ -114,7 +114,15 @@ public class FileStatistics extends BaseTask {
             String result = builder.toString();
             stdout = result;
 
+            process.waitFor();
 
+            int processReturnValue = process.exitValue();
+            if (processReturnValue != 0) {
+                String message = " non-zero return value (" + Integer.toString(processReturnValue) + ")";
+                throw new TaskException(getDescription() + message);
+            }
+        } catch (InterruptedException e) {
+            throw new TaskException(getDescription(), e);
         } catch (IOException e) {
             throw new TaskException(getDescription(), e);
         }

--- a/src/storagemanager/src/main/java/org/vpac/ndg/task/FileStatistics.java
+++ b/src/storagemanager/src/main/java/org/vpac/ndg/task/FileStatistics.java
@@ -87,7 +87,7 @@ public class FileStatistics extends BaseTask {
 
 
     @Override
-    public void execute(Collection<String> actionLog, IProgressCallback progressCallback) throws TaskException {
+    public void execute(Collection<String> actionLog, ProgressCallback progressCallback) throws TaskException {
         List<String> command = prepareCommand();
 
         String listString = "";

--- a/src/storagemanager/src/main/java/org/vpac/ndg/task/GraphicsFileCreator.java
+++ b/src/storagemanager/src/main/java/org/vpac/ndg/task/GraphicsFileCreator.java
@@ -57,10 +57,10 @@ public class GraphicsFileCreator extends Task {
 		if(target == null) {
 			throw new TaskInitialisationException(getDescription(), Constant.ERR_TARGET_DATASET_NOT_SPECIFIED);
 		}
-	}	
-	
+	}
+
 	@Override
-	public void execute(Collection<String> actionLog) throws TaskException {
+	public void execute(Collection<String> actionLog, IProgressCallback progressCallback) throws TaskException {
 		if(source.isEmpty()) {
 			throw new TaskException(getDescription(), Constant.ERR_NO_INPUT_IMAGES);
 		}
@@ -87,12 +87,12 @@ public class GraphicsFileCreator extends Task {
 
 	@Override
 	public void rollback() {
-		// Do nothing		
+		// Do nothing
 	}
 
 	@Override
 	public void finalise() {
-		// Do nothing		
+		// Do nothing
 	}
 
 	public void setSource(List<TileBand> source) {

--- a/src/storagemanager/src/main/java/org/vpac/ndg/task/GraphicsFileCreator.java
+++ b/src/storagemanager/src/main/java/org/vpac/ndg/task/GraphicsFileCreator.java
@@ -60,7 +60,7 @@ public class GraphicsFileCreator extends BaseTask {
 	}
 
 	@Override
-	public void execute(Collection<String> actionLog, IProgressCallback progressCallback) throws TaskException {
+	public void execute(Collection<String> actionLog, ProgressCallback progressCallback) throws TaskException {
 		if(source.isEmpty()) {
 			throw new TaskException(getDescription(), Constant.ERR_NO_INPUT_IMAGES);
 		}

--- a/src/storagemanager/src/main/java/org/vpac/ndg/task/GraphicsFileCreator.java
+++ b/src/storagemanager/src/main/java/org/vpac/ndg/task/GraphicsFileCreator.java
@@ -37,7 +37,7 @@ import org.vpac.ndg.storagemanager.GraphicsFile;
  * @author hsumanto
  *
  */
-public class GraphicsFileCreator extends Task {
+public class GraphicsFileCreator extends BaseTask {
 
 	Logger log = LoggerFactory.getLogger(GraphicsFileCreator.class);
 

--- a/src/storagemanager/src/main/java/org/vpac/ndg/task/IProgressCallback.java
+++ b/src/storagemanager/src/main/java/org/vpac/ndg/task/IProgressCallback.java
@@ -1,0 +1,29 @@
+/*
+ * This file is part of the Raster Storage Archive (RSA).
+ *
+ * The RSA is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * The RSA is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * the RSA.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Copyright 2016 VPAC Innovations
+ * http://vpac-innovations.com.au/
+ */
+
+package org.vpac.ndg.task;
+
+/**
+ * defines an interface that allows a child object to communicate progress without
+ * being too aware of parent.
+ */
+public interface IProgressCallback {
+    /** value between 0 and 100 indicating current progress being reported */
+    public void progressUpdated(double progress);
+}

--- a/src/storagemanager/src/main/java/org/vpac/ndg/task/ITask.java
+++ b/src/storagemanager/src/main/java/org/vpac/ndg/task/ITask.java
@@ -28,13 +28,13 @@ public interface ITask {
 	/**
 	 * Perform initialisation on the task.
 	 * @throws TaskInitialisationException An error encountered during initialisation of the task.
-	 */	
+	 */
 	public void initialise() throws TaskInitialisationException;
 	/**
 	 * Perform the execution of the task.
 	 * @throws TaskException An error ecountered during execution of the task.
 	 */
-	public void execute(Collection<String> actionLog) throws TaskException;
+	public void execute(Collection<String> actionLog, IProgressCallback progressCallback) throws TaskException;
 	/**
 	 * Perform the required rollback action when task execution has failed.
 	 */
@@ -48,5 +48,8 @@ public interface ITask {
 	 * @return Returns the description of the task.
 	 */
 	public String getDescription();
-
+	/**
+	 * Get the contribution of this task to task piplines overall progress
+	 */
+	public double getProgressWeight();
 }

--- a/src/storagemanager/src/main/java/org/vpac/ndg/task/ImageTranslator.java
+++ b/src/storagemanager/src/main/java/org/vpac/ndg/task/ImageTranslator.java
@@ -32,9 +32,9 @@ import org.vpac.ndg.storagemanager.GraphicsFile;
 /**
  * This class responsible to translate an image from one format to another
  * format.
- * 
+ *
  * @author hsumanto
- * 
+ *
  */
 public class ImageTranslator extends Translator {
 
@@ -72,7 +72,7 @@ public class ImageTranslator extends Translator {
 	}
 
 	@Override
-	public void execute(Collection<String> actionLog) throws TaskException {
+	public void execute(Collection<String> actionLog, IProgressCallback progressCallback) throws TaskException {
 		if (getLayerIndex() < 1) {
 			// If invalid layer index specified then throws exception
 			throw new TaskException(getDescription(),

--- a/src/storagemanager/src/main/java/org/vpac/ndg/task/ImageTranslator.java
+++ b/src/storagemanager/src/main/java/org/vpac/ndg/task/ImageTranslator.java
@@ -72,7 +72,7 @@ public class ImageTranslator extends Translator {
 	}
 
 	@Override
-	public void execute(Collection<String> actionLog, IProgressCallback progressCallback) throws TaskException {
+	public void execute(Collection<String> actionLog, ProgressCallback progressCallback) throws TaskException {
 		if (getLayerIndex() < 1) {
 			// If invalid layer index specified then throws exception
 			throw new TaskException(getDescription(),

--- a/src/storagemanager/src/main/java/org/vpac/ndg/task/NcmlBuilder.java
+++ b/src/storagemanager/src/main/java/org/vpac/ndg/task/NcmlBuilder.java
@@ -39,7 +39,7 @@ import org.vpac.ndg.storagemanager.GraphicsFile;
 public class NcmlBuilder extends Task {
 
 	final static Logger log = LoggerFactory.getLogger(NcmlBuilder.class);
-	
+
 	private List<GraphicsFile> rawSource;
 	private List<ScalarReceiver<AggregationDefinition>> nestedSource;
 
@@ -92,29 +92,29 @@ public class NcmlBuilder extends Task {
 	}
 
 	@Override
-	public void execute(Collection<String> actionLog) throws TaskException {
+	public void execute(Collection<String> actionLog, IProgressCallback progressCallback) throws TaskException {
 		AggregationDefinition ds = null;
 		try {
-			List<AggregationDefinition> children;			
+			List<AggregationDefinition> children;
 			switch (type) {
 			case UNION:
 				children = getChildren();
 				ds = factory.union(children, bandNames);
 				break;
-		
+
 			case JOIN_NEW:
 				children = getChildren();
 				ds = factory.joinNew(children, bandNames, newDimension,
 						coordinateValues);
 				break;
-		
+
 			default:
 				throw new TaskException(getDescription(),
 						String.format("Unrecognised aggregation type \"%s\" specified", type));
 			}
 		}
 		catch (IllegalArgumentException e) {
-			throw new TaskException(getDescription(), e.getMessage());			
+			throw new TaskException(getDescription(), e.getMessage());
 		}
 
 		if(ds == null) {
@@ -138,7 +138,7 @@ public class NcmlBuilder extends Task {
 	 * This class can have one of two input types: a list of
 	 * {@link GraphicsFile}s, or a list of {@link AggregationDefinition}s. This function
 	 * coerces them into a common type.
-	 * 
+	 *
 	 * @return The input for this task.
 	 * @throws TaskException
 	 *             If neither of the sources were specified.
@@ -165,7 +165,7 @@ public class NcmlBuilder extends Task {
 			for (ScalarReceiver<AggregationDefinition> child : nestedSource) {
 				AggregationDefinition aggDef = child.get();
 				if (aggDef != null) {
-					// If aggregation exists then only add this aggregation as child dataset  
+					// If aggregation exists then only add this aggregation as child dataset
 					children.add(child.get());
 					// Keep track valid time unit (of valid aggregation)
 					validCoordinateValues.add(coordinateValues.get(childIndex));
@@ -242,7 +242,7 @@ public class NcmlBuilder extends Task {
 	/**
 	 * Set which variables (bands) will be aggregated. When creating a union,
 	 * these must be specified.
-	 * 
+	 *
 	 * @param bandNames
 	 *            The name of each band to aggregate. This must have a 1:1
 	 *            mapping with the source images (see

--- a/src/storagemanager/src/main/java/org/vpac/ndg/task/NcmlBuilder.java
+++ b/src/storagemanager/src/main/java/org/vpac/ndg/task/NcmlBuilder.java
@@ -36,7 +36,7 @@ import org.vpac.ndg.exceptions.TaskException;
 import org.vpac.ndg.exceptions.TaskInitialisationException;
 import org.vpac.ndg.storagemanager.GraphicsFile;
 
-public class NcmlBuilder extends Task {
+public class NcmlBuilder extends BaseTask {
 
 	final static Logger log = LoggerFactory.getLogger(NcmlBuilder.class);
 

--- a/src/storagemanager/src/main/java/org/vpac/ndg/task/NcmlBuilder.java
+++ b/src/storagemanager/src/main/java/org/vpac/ndg/task/NcmlBuilder.java
@@ -92,7 +92,7 @@ public class NcmlBuilder extends BaseTask {
 	}
 
 	@Override
-	public void execute(Collection<String> actionLog, IProgressCallback progressCallback) throws TaskException {
+	public void execute(Collection<String> actionLog, ProgressCallback progressCallback) throws TaskException {
 		AggregationDefinition ds = null;
 		try {
 			List<AggregationDefinition> children;

--- a/src/storagemanager/src/main/java/org/vpac/ndg/task/NoOperation.java
+++ b/src/storagemanager/src/main/java/org/vpac/ndg/task/NoOperation.java
@@ -41,7 +41,7 @@ public class NoOperation extends BaseTask {
 	}
 
 	@Override
-	public void execute(Collection<String> actionLog, IProgressCallback progressCallback) throws TaskException {
+	public void execute(Collection<String> actionLog, ProgressCallback progressCallback) throws TaskException {
 		// Do nothing
 	}
 

--- a/src/storagemanager/src/main/java/org/vpac/ndg/task/NoOperation.java
+++ b/src/storagemanager/src/main/java/org/vpac/ndg/task/NoOperation.java
@@ -41,7 +41,7 @@ public class NoOperation extends Task {
 	}
 
 	@Override
-	public void execute(Collection<String> actionLog) throws TaskException {
+	public void execute(Collection<String> actionLog, IProgressCallback progressCallback) throws TaskException {
 		// Do nothing
 	}
 

--- a/src/storagemanager/src/main/java/org/vpac/ndg/task/NoOperation.java
+++ b/src/storagemanager/src/main/java/org/vpac/ndg/task/NoOperation.java
@@ -29,7 +29,7 @@ import org.vpac.ndg.exceptions.TaskException;
  * @author hsumanto
  *
  */
-public class NoOperation extends Task {
+public class NoOperation extends BaseTask {
 
 	public NoOperation(String description) {
 		super(Constant.TASK_DESCRIPTION_NOOP);

--- a/src/storagemanager/src/main/java/org/vpac/ndg/task/OutputDirStatistics.java
+++ b/src/storagemanager/src/main/java/org/vpac/ndg/task/OutputDirStatistics.java
@@ -23,7 +23,7 @@ import org.vpac.ndg.storagemanager.GraphicsFile;
  * @author lachlan
  *
  */
-public class OutputDirStatistics extends Task {
+public class OutputDirStatistics extends BaseTask {
 
     final private Logger log = LoggerFactory.getLogger(OutputDirStatistics.class);
 

--- a/src/storagemanager/src/main/java/org/vpac/ndg/task/OutputDirStatistics.java
+++ b/src/storagemanager/src/main/java/org/vpac/ndg/task/OutputDirStatistics.java
@@ -32,22 +32,22 @@ public class OutputDirStatistics extends Task {
     private final String STATS_MIN = "STATISTICS_MINIMUM";
     private final String PIXEL_TYPE = "PIXELTYPE";
     private final String NO_DATA = "NoData Value";
-    
+
     private Path sourceDir;
     private boolean approximate;
-    
+
     //the gathered stats
     private ScalarReceiver<Double> max;
     private ScalarReceiver<Double> min;
     private ScalarReceiver<Double> nodata;
     private ScalarReceiver<String> pixelType;
 
-    
-    
+
+
     public OutputDirStatistics() {
         this("Extracting statistics from output dir");
     }
-    
+
     public OutputDirStatistics(String description) {
         super(description);
     }
@@ -69,28 +69,28 @@ public class OutputDirStatistics extends Task {
 
         command.add("-noct");
         // command.add("-mm");
-        
+
         if (approximate) {
             command.add("-approx_stats");
         } else {
             command.add("-stats");
         }
-        
+
         // command.add(source.getFileLocation().toString());
         // log.info("command:" + command);
         return command;
     }
 
-    
-    
+
+
     @Override
-    public void execute(Collection<String> actionLog) throws TaskException {
-        
+    public void execute(Collection<String> actionLog, IProgressCallback progressCallback) throws TaskException {
+
         try {
             Files.walk(sourceDir).forEach(filePath -> {
                 String stdout = "";
                 List<String> command = prepareCommand();
-                
+
                 String listString = "";
                 for (String s : command) {
                     listString += s + " ";
@@ -106,7 +106,7 @@ public class OutputDirStatistics extends Task {
                         actionLog.add(StringUtils.join(command, " "));
                         ProcessBuilder pb = new ProcessBuilder(command);
                         Process process = pb.start();
-                        
+
                         BufferedReader br = new BufferedReader(new InputStreamReader(process.getInputStream()));
                         StringBuilder builder = new StringBuilder();
                         String line = null;
@@ -123,8 +123,8 @@ public class OutputDirStatistics extends Task {
                     //We'll end up with a block of data at the end of this similar to
                     //STATISTICS_MAXIMUM=389
                     //STATISTICS_MINIMUM=300
-                     
-                    
+
+
                     //Read the info we're after and put it in some scalar receivers
                     String lines[] = stdout.split(System.lineSeparator());
                     for (String line2: lines) {
@@ -160,7 +160,7 @@ public class OutputDirStatistics extends Task {
         String numberBit = line.substring(line.indexOf('=')+1);
         return Double.parseDouble(numberBit);
     }
-    
+
     private void setComputedValues(String line) {
         String minAndMax = line.substring(line.indexOf('=')+1);
         Double min = Double.parseDouble(minAndMax.split(",")[0]);

--- a/src/storagemanager/src/main/java/org/vpac/ndg/task/OutputDirStatistics.java
+++ b/src/storagemanager/src/main/java/org/vpac/ndg/task/OutputDirStatistics.java
@@ -84,7 +84,7 @@ public class OutputDirStatistics extends BaseTask {
 
 
     @Override
-    public void execute(Collection<String> actionLog, IProgressCallback progressCallback) throws TaskException {
+    public void execute(Collection<String> actionLog, ProgressCallback progressCallback) throws TaskException {
 
         try {
             Files.walk(sourceDir).forEach(filePath -> {

--- a/src/storagemanager/src/main/java/org/vpac/ndg/task/ProgressCallback.java
+++ b/src/storagemanager/src/main/java/org/vpac/ndg/task/ProgressCallback.java
@@ -23,7 +23,7 @@ package org.vpac.ndg.task;
  * defines an interface that allows a child object to communicate progress without
  * being too aware of parent.
  */
-public interface IProgressCallback {
+public interface ProgressCallback {
     /** value between 0 and 100 indicating current progress being reported */
     public void progressUpdated(double progress);
 }

--- a/src/storagemanager/src/main/java/org/vpac/ndg/task/Task.java
+++ b/src/storagemanager/src/main/java/org/vpac/ndg/task/Task.java
@@ -24,7 +24,7 @@ import java.util.Collection;
 import org.vpac.ndg.exceptions.TaskException;
 import org.vpac.ndg.exceptions.TaskInitialisationException;
 
-public interface ITask {
+public interface Task {
 	/**
 	 * Perform initialisation on the task.
 	 * @throws TaskInitialisationException An error encountered during initialisation of the task.

--- a/src/storagemanager/src/main/java/org/vpac/ndg/task/Task.java
+++ b/src/storagemanager/src/main/java/org/vpac/ndg/task/Task.java
@@ -19,8 +19,10 @@
 
 package org.vpac.ndg.task;
 
-import org.vpac.ndg.storage.model.JobProgress;
+import java.util.Collection;
 
+import org.vpac.ndg.storage.model.JobProgress;
+import org.vpac.ndg.exceptions.TaskException;
 /**
  * This abstract class represents a command to be executed.
  * @author hsumanto
@@ -37,6 +39,8 @@ public abstract class Task implements ITask {
 	private boolean cleanupTarget;
 	/** Perform checking on source during execution */
 	private boolean checkSource;
+	/** Weight indicating how much contribution this task has to a task pipeline*/
+	private double progressWeight = 0.0;
 	/**
 	 * Construct a task using the specified description.
 	 * @param description The given task description.
@@ -49,7 +53,12 @@ public abstract class Task implements ITask {
 		// By default check source during execution
 		setCheckSource(true);
 	}
-	
+
+	public void execute(Collection<String> actionLog) throws TaskException {
+		//implemented to maintain compatibility with previous ITask interface
+		this.execute(actionLog, null);
+	}
+
 	public void setDescription(String description) {
 		this.description = description;
 	}
@@ -90,4 +99,11 @@ public abstract class Task implements ITask {
 		this.checkSource = checkSource;
 	}
 
+	public double getProgressWeight() {
+		return progressWeight;
+	}
+
+	public void setProgressWeight(double progressWeight) {
+		this.progressWeight = progressWeight;
+	}
 }

--- a/src/storagemanager/src/main/java/org/vpac/ndg/task/Task.java
+++ b/src/storagemanager/src/main/java/org/vpac/ndg/task/Task.java
@@ -40,7 +40,7 @@ public abstract class Task implements ITask {
 	/** Perform checking on source during execution */
 	private boolean checkSource;
 	/** Weight indicating how much contribution this task has to a task pipeline*/
-	private double progressWeight = 0.0;
+	private double progressWeight = 1.0;
 	/**
 	 * Construct a task using the specified description.
 	 * @param description The given task description.

--- a/src/storagemanager/src/main/java/org/vpac/ndg/task/Task.java
+++ b/src/storagemanager/src/main/java/org/vpac/ndg/task/Task.java
@@ -34,7 +34,7 @@ public interface Task {
 	 * Perform the execution of the task.
 	 * @throws TaskException An error ecountered during execution of the task.
 	 */
-	public void execute(Collection<String> actionLog, IProgressCallback progressCallback) throws TaskException;
+	public void execute(Collection<String> actionLog, ProgressCallback progressCallback) throws TaskException;
 	/**
 	 * Perform the required rollback action when task execution has failed.
 	 */

--- a/src/storagemanager/src/main/java/org/vpac/ndg/task/TaskPipeline.java
+++ b/src/storagemanager/src/main/java/org/vpac/ndg/task/TaskPipeline.java
@@ -49,7 +49,7 @@ public class TaskPipeline implements IProgressCallback {
 	/** task pipeline name */
 	private String name;
 	/** task pipeline queue */
-	private List<ITask> queue;
+	private List<Task> queue;
 	/** for communicating a raster task's progress to the outside world */
 	private JobProgress progress;
 	/** for differentiating main pipeline and child pipeline */
@@ -66,7 +66,7 @@ public class TaskPipeline implements IProgressCallback {
 
 	public TaskPipeline(boolean isMain) {
 		setMain(isMain);
-		queue = new ArrayList<ITask>();
+		queue = new ArrayList<Task>();
 		ApplicationContext appContext = ApplicationContextProvider.getApplicationContext();
 		jobProgressDao = (JobProgressDao) appContext.getBean("jobProgressDao");
 		if(isMain()) {
@@ -87,7 +87,7 @@ public class TaskPipeline implements IProgressCallback {
 	 * Add a task into task pipeline.
 	 * @param task The task to add into pipeline.
 	 */
-	public void addTask(ITask task) {
+	public void addTask(Task task) {
 		queue.add(task);
 	}
 
@@ -107,7 +107,7 @@ public class TaskPipeline implements IProgressCallback {
 
 		int currTaskStep = 1;
 		// Perform any necessary initialisation before execution
-		for (ITask task : queue) {
+		for (Task task : queue) {
 			log.debug(String.format("%sTASK_INIT [%s] = %s", tab,
 					currTaskStep, task.getDescription()));
 			task.initialise();
@@ -135,7 +135,7 @@ public class TaskPipeline implements IProgressCallback {
 
 		int currTaskStep = 1;
 		// Perform execution of each task in pipeline
-		for (ITask task : queue) {
+		for (Task task : queue) {
 			log.debug(String.format("%sTASK_EXEC [%s] = %s", tab,
 					currTaskStep, task.getDescription()));
 			task.execute(actionLog, this);
@@ -159,7 +159,7 @@ public class TaskPipeline implements IProgressCallback {
 
 		log.info("{}ROLLBACK", tab);
 
-		for (ITask task : queue) {
+		for (Task task : queue) {
 			try {
 				task.rollback();
 			} catch (RuntimeException e) {
@@ -186,7 +186,7 @@ public class TaskPipeline implements IProgressCallback {
 
 		int currTaskStep = 1;
 		// Perform finalise of each task in pipeline
-		for (ITask task : queue) {
+		for (Task task : queue) {
 			try {
 				log.debug(String.format("%sTASK_CLEANUP [%s] = %s", tab,
 						currTaskStep, task.getDescription()));
@@ -208,7 +208,7 @@ public class TaskPipeline implements IProgressCallback {
 		return name;
 	}
 
-	public List<ITask> getQueue() {
+	public List<Task> getQueue() {
 		return queue;
 	}
 
@@ -274,7 +274,7 @@ public class TaskPipeline implements IProgressCallback {
 		//calculate progress based on weights of each task
 		double weightedProgressSum = 0.0;
 		for (int i = 0; i < currTaskStep; i++) {
-			ITask t = queue.get(i);
+			Task t = queue.get(i);
 			weightedProgressSum += t.getProgressWeight();
 		}
 		double weightedProgressPercent = weightedProgressSum / totalTaskPipelineWeight * 100.0;
@@ -292,7 +292,7 @@ public class TaskPipeline implements IProgressCallback {
 		//calculate weighted sum of completed tasks
 		double weightedProgressSum = 0.0;
 		for (int i = 0; i < currentStep; i++) {
-			ITask t = queue.get(i);
+			Task t = queue.get(i);
 			weightedProgressSum += t.getProgressWeight();
 		}
 

--- a/src/storagemanager/src/main/java/org/vpac/ndg/task/TaskPipeline.java
+++ b/src/storagemanager/src/main/java/org/vpac/ndg/task/TaskPipeline.java
@@ -40,7 +40,7 @@ import org.vpac.ndg.storage.model.JobProgress;
  * Manages a collection of tasks as a transaction.
  * @author hsumanto
  */
-public class TaskPipeline implements IProgressCallback {
+public class TaskPipeline implements ProgressCallback {
 
 	final private Logger log = LoggerFactory.getLogger(TaskPipeline.class);
 

--- a/src/storagemanager/src/main/java/org/vpac/ndg/task/TileAggregator.java
+++ b/src/storagemanager/src/main/java/org/vpac/ndg/task/TileAggregator.java
@@ -109,7 +109,7 @@ public class TileAggregator extends Task {
 	}
 
 	@Override
-	public void execute(Collection<String> actionLog) throws TaskException {
+	public void execute(Collection<String> actionLog, IProgressCallback progressCallback) throws TaskException {
 		revalidateBeforeExecution();
 
 		List<Path> tileList = new ArrayList<Path>();

--- a/src/storagemanager/src/main/java/org/vpac/ndg/task/TileAggregator.java
+++ b/src/storagemanager/src/main/java/org/vpac/ndg/task/TileAggregator.java
@@ -109,7 +109,7 @@ public class TileAggregator extends BaseTask {
 	}
 
 	@Override
-	public void execute(Collection<String> actionLog, IProgressCallback progressCallback) throws TaskException {
+	public void execute(Collection<String> actionLog, ProgressCallback progressCallback) throws TaskException {
 		revalidateBeforeExecution();
 
 		List<Path> tileList = new ArrayList<Path>();

--- a/src/storagemanager/src/main/java/org/vpac/ndg/task/TileAggregator.java
+++ b/src/storagemanager/src/main/java/org/vpac/ndg/task/TileAggregator.java
@@ -43,7 +43,7 @@ import org.vpac.ndg.storage.model.TimeSlice;
 import org.vpac.ndg.storage.util.TimeSliceUtil;
 import org.vpac.ndg.storagemanager.GraphicsFile;
 
-public class TileAggregator extends Task {
+public class TileAggregator extends BaseTask {
 
 	final private Logger log = LoggerFactory.getLogger(TileAggregator.class);
 

--- a/src/storagemanager/src/main/java/org/vpac/ndg/task/TileBandCreator.java
+++ b/src/storagemanager/src/main/java/org/vpac/ndg/task/TileBandCreator.java
@@ -74,37 +74,37 @@ public class TileBandCreator extends Task {
 
 	@Override
 	public void initialise() throws TaskInitialisationException {
-		// Perform validation 
+		// Perform validation
 		if(source == null) {
 			throw new TaskInitialisationException(getDescription(), "Source extents not specified.");
 		}
-		
+
 		if(target == null) {
 			throw new TaskInitialisationException(getDescription(), "Target tileband not specified.");
 		}
-		
+
 		if(getTimeSlice() == null) {
 			throw new TaskInitialisationException(getDescription(), Constant.ERR_TIMESLICE_NOT_SPECIFIED);
 		}
-		
+
 		Dataset ds = timeSliceDao.getParentDataset(getTimeSlice().getId());
 		if(ds == null) {
 			throw new TaskInitialisationException(getDescription(), Constant.ERR_TIMESLICE_PARENT_NOT_SPECIFIED);
 		}
-		
+
 		if(band == null || (bandDao.find(ds.getId(), band.getName()) == null)) {
 			throw new TaskInitialisationException(getDescription(), Constant.ERR_DATASET_BANDS_NOT_SPECIFIED);
 		}
-	}	
-	
+	}
+
 	@Override
-	public void execute(Collection<String> actionLog) throws TaskException {
+	public void execute(Collection<String> actionLog, IProgressCallback progressCallback) throws TaskException {
 		// Perform some neccessary validation
 		Dataset ds = timeSliceDao.getParentDataset(getTimeSlice().getId());
 		if(ds == null) {
 			throw new TaskException(getDescription(), Constant.ERR_TIMESLICE_PARENT_NOT_SPECIFIED);
 		}
-		
+
 		if(band == null || (bandDao.find(ds.getId(), band.getName()) == null)) {
 			throw new TaskException(getDescription(), Constant.ERR_DATASET_BANDS_NOT_SPECIFIED);
 		}
@@ -113,9 +113,9 @@ public class TileBandCreator extends Task {
 		List<Tile> tiles = tileManager.getTiles(source, ds.getResolution());
 
 		// Create tileband for each tile
-		for(Tile tile : tiles) {	
-			TileBand tileband = new TileBand(tile, band, timeSlice); 
-			target.add(tileband);	
+		for(Tile tile : tiles) {
+			TileBand tileband = new TileBand(tile, band, timeSlice);
+			target.add(tileband);
 			log.trace("{}", tileband);
 			//log.debug("tileband resolution: {}", timeSlice.getParent().getResolution());
 		}
@@ -123,12 +123,12 @@ public class TileBandCreator extends Task {
 
 	@Override
 	public void rollback() {
-		// Do nothing		
+		// Do nothing
 	}
 
 	@Override
 	public void finalise() {
-		// Do nothing		
+		// Do nothing
 	}
 
 	public void setSource(Box source) {

--- a/src/storagemanager/src/main/java/org/vpac/ndg/task/TileBandCreator.java
+++ b/src/storagemanager/src/main/java/org/vpac/ndg/task/TileBandCreator.java
@@ -98,7 +98,7 @@ public class TileBandCreator extends BaseTask {
 	}
 
 	@Override
-	public void execute(Collection<String> actionLog, IProgressCallback progressCallback) throws TaskException {
+	public void execute(Collection<String> actionLog, ProgressCallback progressCallback) throws TaskException {
 		// Perform some neccessary validation
 		Dataset ds = timeSliceDao.getParentDataset(getTimeSlice().getId());
 		if(ds == null) {

--- a/src/storagemanager/src/main/java/org/vpac/ndg/task/TileBandCreator.java
+++ b/src/storagemanager/src/main/java/org/vpac/ndg/task/TileBandCreator.java
@@ -44,7 +44,7 @@ import org.vpac.ndg.storage.model.TimeSlice;
  * @author hsumanto
  *
  */
-public class TileBandCreator extends Task {
+public class TileBandCreator extends BaseTask {
 
 	final private Logger log = LoggerFactory.getLogger(TileBandCreator.class);
 

--- a/src/storagemanager/src/main/java/org/vpac/ndg/task/TileBandFilter.java
+++ b/src/storagemanager/src/main/java/org/vpac/ndg/task/TileBandFilter.java
@@ -36,7 +36,7 @@ import org.vpac.ndg.storage.model.TileBand;
  * @author hsumanto
  * @author adfries
  */
-public class TileBandFilter extends Task {
+public class TileBandFilter extends BaseTask {
 
 	Logger log = LoggerFactory.getLogger(TileBandFilter.class);
 

--- a/src/storagemanager/src/main/java/org/vpac/ndg/task/TileBandFilter.java
+++ b/src/storagemanager/src/main/java/org/vpac/ndg/task/TileBandFilter.java
@@ -56,10 +56,10 @@ public class TileBandFilter extends Task {
 		if(target == null) {
 			throw new TaskInitialisationException(getDescription(), Constant.ERR_TARGET_DATASET_NOT_SPECIFIED);
 		}
-	}	
-	
+	}
+
 	@Override
-	public void execute(Collection<String> actionLog) throws TaskException {
+	public void execute(Collection<String> actionLog, IProgressCallback progressCallback) throws TaskException {
 		if (source.isEmpty()) {
 			throw new TaskException(getDescription(), Constant.ERR_NO_INPUT_IMAGES);
 		}
@@ -79,12 +79,12 @@ public class TileBandFilter extends Task {
 
 	@Override
 	public void rollback() {
-		// Do nothing		
+		// Do nothing
 	}
 
 	@Override
 	public void finalise() {
-		// Do nothing		
+		// Do nothing
 	}
 
 	public void setSource(List<TileBand> source) {

--- a/src/storagemanager/src/main/java/org/vpac/ndg/task/TileBandFilter.java
+++ b/src/storagemanager/src/main/java/org/vpac/ndg/task/TileBandFilter.java
@@ -59,7 +59,7 @@ public class TileBandFilter extends BaseTask {
 	}
 
 	@Override
-	public void execute(Collection<String> actionLog, IProgressCallback progressCallback) throws TaskException {
+	public void execute(Collection<String> actionLog, ProgressCallback progressCallback) throws TaskException {
 		if (source.isEmpty()) {
 			throw new TaskException(getDescription(), Constant.ERR_NO_INPUT_IMAGES);
 		}

--- a/src/storagemanager/src/main/java/org/vpac/ndg/task/TileBuilder.java
+++ b/src/storagemanager/src/main/java/org/vpac/ndg/task/TileBuilder.java
@@ -125,6 +125,16 @@ public class TileBuilder extends BaseTask {
                     progressCallback.progressUpdated(progressPercentage);
                 }
             }
+
+            process.waitFor();
+
+            int processReturnValue = process.exitValue();
+            if (processReturnValue != 0) {
+                String message = " non-zero return value (" + Integer.toString(processReturnValue) + ")";
+                throw new TaskException(getDescription() + message);
+            }
+        } catch (InterruptedException e) {
+            throw new TaskException(getDescription(), e);
         } catch (IOException e) {
             throw new TaskException(getDescription(), e);
         }

--- a/src/storagemanager/src/main/java/org/vpac/ndg/task/TileBuilder.java
+++ b/src/storagemanager/src/main/java/org/vpac/ndg/task/TileBuilder.java
@@ -98,7 +98,7 @@ public class TileBuilder extends BaseTask {
     }
 
     @Override
-    public void execute(Collection<String> actionLog, IProgressCallback progressCallback) throws TaskException {
+    public void execute(Collection<String> actionLog, ProgressCallback progressCallback) throws TaskException {
 
         List<String> command = prepareCommand();
 		actionLog.add(StringUtils.join(command, " "));

--- a/src/storagemanager/src/main/java/org/vpac/ndg/task/TileBuilder.java
+++ b/src/storagemanager/src/main/java/org/vpac/ndg/task/TileBuilder.java
@@ -120,7 +120,7 @@ public class TileBuilder extends Task {
                 if (ch == '.') {
                     progressInt += 1;
                 }
-                double progressPercentage = (double)progressInt/(double)totalFullStops * 100.0;
+                double progressPercentage = (double)progressInt/(double)totalFullStops;
                 if (progressCallback != null) {
                     progressCallback.progressUpdated(progressPercentage);
                 }

--- a/src/storagemanager/src/main/java/org/vpac/ndg/task/TileBuilder.java
+++ b/src/storagemanager/src/main/java/org/vpac/ndg/task/TileBuilder.java
@@ -1,5 +1,7 @@
 package org.vpac.ndg.task;
 
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -16,6 +18,7 @@ import org.vpac.ndg.common.StringUtils;
 import org.vpac.ndg.exceptions.TaskException;
 import org.vpac.ndg.exceptions.TaskInitialisationException;
 import org.vpac.ndg.rasterservices.ProcessException;
+import org.vpac.ndg.storage.model.JobProgress;
 import org.vpac.ndg.storagemanager.GraphicsFile;
 
 /**
@@ -31,14 +34,14 @@ public class TileBuilder extends Task {
     private String profile;
     private int zoomMax = 7;
     private int zoomMin = 0;
-    
+
     private CommandUtil commandUtil;
-    final private Logger log = LoggerFactory.getLogger(VrtBuilder.class);
-    
+    final private Logger log = LoggerFactory.getLogger(TileBuilder.class);
+
     public TileBuilder() {
         this("Building tiles");
     }
-    
+
     public TileBuilder(String description) {
         super(description);
         commandUtil = new CommandUtil();
@@ -55,7 +58,7 @@ public class TileBuilder extends Task {
             throw new TaskInitialisationException(getDescription(),
                     Constant.ERR_TARGET_DATASET_NOT_SPECIFIED);
         }
-        
+
         if (getTarget().toFile().exists()) {
             //then delete it, will be old data
             try {
@@ -64,7 +67,7 @@ public class TileBuilder extends Task {
                 throw new TaskInitialisationException("Unable to delete old WMTS tiles directory", e);
             }
         }
-        
+
         boolean created = getTarget().toFile().mkdirs();
         if (!created) {
             throw new TaskInitialisationException("Could not create directory for output WMTS tiles");
@@ -94,23 +97,37 @@ public class TileBuilder extends Task {
         return command;
     }
 
-    
-    
     @Override
-    public void execute(Collection<String> actionLog) throws TaskException {
-        
+    public void execute(Collection<String> actionLog, IProgressCallback progressCallback) throws TaskException {
+
         List<String> command = prepareCommand();
 		actionLog.add(StringUtils.join(command, " "));
         try {
-            commandUtil.start(command);
-        } catch (ProcessException e) {
-            throw new TaskException(getDescription(), e);
-        } catch (InterruptedException e) {
-            throw new TaskException(getDescription(), e);
+            ProcessBuilder pb = new ProcessBuilder(command);
+            Process process = pb.start();
+
+            //gdal2tiles runs from 0-100 twice, once for base tiles, and once for overlay tiles
+            //to count progress all we do is sum up the total number of dots printed to stdout
+            // there should be a total of 62, including the ones after "done".
+            int progressInt = 0;
+            int totalFullStops = 62;
+
+            InputStreamReader r = new InputStreamReader(process.getInputStream());
+            int intch;
+
+            while ((intch = r.read()) != -1) {
+                char ch = (char) intch;
+                if (ch == '.') {
+                    progressInt += 1;
+                }
+                double progressPercentage = (double)progressInt/(double)totalFullStops * 100.0;
+                if (progressCallback != null) {
+                    progressCallback.progressUpdated(progressPercentage);
+                }
+            }
         } catch (IOException e) {
             throw new TaskException(getDescription(), e);
         }
-
     }
 
     @Override
@@ -125,7 +142,7 @@ public class TileBuilder extends Task {
 
     }
 
-    
+
     public int getZoomMax() {
         return zoomMax;
     }
@@ -170,9 +187,9 @@ public class TileBuilder extends Task {
         this.profile = process;
     }
 
-    
-    
-    
-    
-    
+
+
+
+
+
 }

--- a/src/storagemanager/src/main/java/org/vpac/ndg/task/TileBuilder.java
+++ b/src/storagemanager/src/main/java/org/vpac/ndg/task/TileBuilder.java
@@ -27,7 +27,7 @@ import org.vpac.ndg.storagemanager.GraphicsFile;
  * @author lachlan
  *
  */
-public class TileBuilder extends Task {
+public class TileBuilder extends BaseTask {
 
     private GraphicsFile source;
     private Path target;  //in this case the target is simply a directory

--- a/src/storagemanager/src/main/java/org/vpac/ndg/task/TileTransformer.java
+++ b/src/storagemanager/src/main/java/org/vpac/ndg/task/TileTransformer.java
@@ -93,7 +93,7 @@ public class TileTransformer extends BaseTask {
 	}
 
 	@Override
-	public void execute(Collection<String> actionLog, IProgressCallback progressCallback) throws TaskException {
+	public void execute(Collection<String> actionLog, ProgressCallback progressCallback) throws TaskException {
 		innerTaskPipeline.setActionLog(actionLog);
 
 		for(TileBand tileBand: target) {

--- a/src/storagemanager/src/main/java/org/vpac/ndg/task/TileTransformer.java
+++ b/src/storagemanager/src/main/java/org/vpac/ndg/task/TileTransformer.java
@@ -42,7 +42,7 @@ import org.vpac.ndg.storagemanager.GraphicsFile;
  * @author hsumanto
  *
  */
-public class TileTransformer extends Task {
+public class TileTransformer extends BaseTask {
 
 	final private Logger log = LoggerFactory.getLogger(TileTransformer.class);
 

--- a/src/storagemanager/src/main/java/org/vpac/ndg/task/TileTransformer.java
+++ b/src/storagemanager/src/main/java/org/vpac/ndg/task/TileTransformer.java
@@ -70,7 +70,7 @@ public class TileTransformer extends Task {
 	}
 
 	@Override
-	public void initialise() throws TaskInitialisationException {	
+	public void initialise() throws TaskInitialisationException {
 		// Perform validation on source and target fields;
 		if(source == null || getSource().isEmpty()) {
 			throw new TaskInitialisationException(getDescription(), Constant.ERR_NO_INPUT_IMAGES);
@@ -93,10 +93,10 @@ public class TileTransformer extends Task {
 	}
 
 	@Override
-	public void execute(Collection<String> actionLog) throws TaskException {
+	public void execute(Collection<String> actionLog, IProgressCallback progressCallback) throws TaskException {
 		innerTaskPipeline.setActionLog(actionLog);
 
-		for(TileBand tileBand: target) {		
+		for(TileBand tileBand: target) {
 			Transformer makeTile = new Transformer("Make Tile " + tileBand.getTileNameWithExtention());
 
 			GraphicsFile transformTile = new GraphicsFile();
@@ -107,7 +107,7 @@ public class TileTransformer extends Task {
 			if(epsgId != -1) {
 				transformTile.setEpsgId(epsgId);
 			}
-			transformTile.setResolution(timeSliceDao.getParentDataset(tileBand.getTimeSlice().getId()).getResolution());			
+			transformTile.setResolution(timeSliceDao.getParentDataset(tileBand.getTimeSlice().getId()).getResolution());
 
 			// Set up source image
 			makeTile.setSource(source);
@@ -137,14 +137,14 @@ public class TileTransformer extends Task {
 
 	@Override
 	public void rollback() {
-		// Call each transformer roll back 
+		// Call each transformer roll back
 		innerTaskPipeline.rollback();
 	}
 
 	@Override
 	public void finalise() {
 		// Call each transformer finalise
-		innerTaskPipeline.finalise();		
+		innerTaskPipeline.finalise();
 	}
 
 	public void setSource(List<GraphicsFile> source) {

--- a/src/storagemanager/src/main/java/org/vpac/ndg/task/TileUpdater.java
+++ b/src/storagemanager/src/main/java/org/vpac/ndg/task/TileUpdater.java
@@ -42,7 +42,7 @@ import org.vpac.ndg.storage.model.TimeSlice;
 import org.vpac.ndg.storage.util.TimeSliceUtil;
 import org.vpac.ndg.storagemanager.GraphicsFile;
 
-public class TileUpdater extends Task {
+public class TileUpdater extends BaseTask {
 
 	final private Logger log = LoggerFactory.getLogger(TileUpdater.class);
 

--- a/src/storagemanager/src/main/java/org/vpac/ndg/task/TileUpdater.java
+++ b/src/storagemanager/src/main/java/org/vpac/ndg/task/TileUpdater.java
@@ -48,7 +48,7 @@ public class TileUpdater extends Task {
 
 	private List<TileBand> source;
 	private List<TileBand> target;
-	private TimeSlice timeSlice;	
+	private TimeSlice timeSlice;
 	private TaskPipeline innerTaskPipeline = new TaskPipeline(false);
 	private Path tempDir;
 	private String srcnodata;
@@ -57,7 +57,7 @@ public class TileUpdater extends Task {
 	TimeSliceDao timeSliceDao;
 	TimeSliceUtil timeSliceUtil;
 	TileManager tileManager;
-	
+
 	public TileUpdater() {
 		this(Constant.TASK_DESCRIPTION_TILEUPDATER);
 	}
@@ -76,10 +76,10 @@ public class TileUpdater extends Task {
 	}
 
 	@Override
-	public void execute(Collection<String> actionLog) throws TaskException {
+	public void execute(Collection<String> actionLog, IProgressCallback progressCallback) throws TaskException {
 		innerTaskPipeline.setActionLog(actionLog);
 
-		for(TileBand tileband: source) {			
+		for(TileBand tileband: source) {
 			Tile t = tileband.getTile();
 			Dataset dataset = timeSliceDao.getParentDataset(timeSlice.getId());
 			Box tileBounds = tileManager.getNngGrid().getBounds(t.getIndex(), dataset.getResolution());
@@ -96,11 +96,11 @@ public class TileUpdater extends Task {
 				log.trace("Found tile {}", t);
 				// Find location of existing tile
 				Path defaultFileLocationForPreviousUpload = tileband.getDefaultFileLocation();
-				// Get new and existing tile images 
+				// Get new and existing tile images
 				GraphicsFile newImage = new GraphicsFile(tileband.getFileLocation());
 				GraphicsFile oldImage = new GraphicsFile(defaultFileLocationForPreviousUpload);
 				log.trace("Old tile: {}", defaultFileLocationForPreviousUpload);
-				// Construct source from new and existing tile images 
+				// Construct source from new and existing tile images
 				List<GraphicsFile> sourceTiles = new ArrayList<GraphicsFile>();
 				sourceTiles.add(oldImage);
 				sourceTiles.add(newImage);
@@ -110,7 +110,7 @@ public class TileUpdater extends Task {
 				Path transformTileFileLocation = tempDir.resolve(transformTileFilename);
 				targetTile.setFileLocation(transformTileFileLocation); // targetTile.setFileLocation("/var/tmp/.../Band1_tile_x1_y1.nc.composite");
 				tileband.setFileLocation(targetTile.getFileLocation());
-				
+
 				Transformer mosaickingTask = new Transformer("Composite new tile on top of exisiting tile " + t.getIndex());
 				// Set up source image
 				mosaickingTask.setSource(sourceTiles);
@@ -138,18 +138,18 @@ public class TileUpdater extends Task {
 		}
 
 		// Run each specific task in inner pipeline
-		innerTaskPipeline.run();	
+		innerTaskPipeline.run();
 		return;
 	}
 
 	@Override
 	public void rollback() {
-		// Call each child task roll back 
+		// Call each child task roll back
 		innerTaskPipeline.rollback();
 	}
 
 	@Override
-	public void finalise() {	
+	public void finalise() {
 		// Call each child task finalise
 		innerTaskPipeline.finalise();
 	}

--- a/src/storagemanager/src/main/java/org/vpac/ndg/task/TileUpdater.java
+++ b/src/storagemanager/src/main/java/org/vpac/ndg/task/TileUpdater.java
@@ -76,7 +76,7 @@ public class TileUpdater extends BaseTask {
 	}
 
 	@Override
-	public void execute(Collection<String> actionLog, IProgressCallback progressCallback) throws TaskException {
+	public void execute(Collection<String> actionLog, ProgressCallback progressCallback) throws TaskException {
 		innerTaskPipeline.setActionLog(actionLog);
 
 		for(TileBand tileband: source) {

--- a/src/storagemanager/src/main/java/org/vpac/ndg/task/Transformer.java
+++ b/src/storagemanager/src/main/java/org/vpac/ndg/task/Transformer.java
@@ -38,9 +38,9 @@ import org.vpac.ndg.storagemanager.GraphicsFile;
 
 /**
  * The task of this class is to transform GraphicsFiles into the intended GraphicsFile.
- * In the target GraphicsFile, user could specify the intended projection, resolution, extents 
- * and format to transform to.  
- * 
+ * In the target GraphicsFile, user could specify the intended projection, resolution, extents
+ * and format to transform to.
+ *
  * @author hsumanto
  *
  */
@@ -68,27 +68,27 @@ public class Transformer extends Task {
 		super(description);
 		commandUtil = new CommandUtil();
 	}
-	
+
 	@Override
 	public void initialise() throws TaskInitialisationException {
 		// Perform validation on source and target fields;
 		if(getSource() == null) {
 			throw new TaskInitialisationException(getDescription(), Constant.ERR_NO_INPUT_IMAGES);
 		}
-		
+
 		if(getTarget() == null) {
 			throw new TaskInitialisationException(getDescription(), Constant.ERR_TARGET_DATASET_NOT_SPECIFIED);
-		}	
-		
+		}
+
 	}
-	
+
 	@Override
-	public void execute(Collection<String> actionLog) throws TaskException {
+	public void execute(Collection<String> actionLog, IProgressCallback progressCallback) throws TaskException {
 		if(isCheckSource()) {
 			if(getSource().isEmpty()) {
 				// During import if no input images then throws exception
 				throw new TaskException(getDescription(), Constant.ERR_NO_INPUT_IMAGES);
-			}			
+			}
 		}
 		else {
 			if(getSource().isEmpty()) {
@@ -99,7 +99,7 @@ public class Transformer extends Task {
 				log.debug("Source is empty; will not transform.");
 				return;
 			}
-		}		
+		}
 
 		// Initialize command parameter list
 		command = new ArrayList<String>();
@@ -113,7 +113,7 @@ public class Transformer extends Task {
 		} else {
 			if(target.getSrs() != null && !target.getSrs().isEmpty()) {
 				command.add("-t_srs");
-				command.add(target.getSrs());							
+				command.add(target.getSrs());
 			}
 		}
 
@@ -127,7 +127,7 @@ public class Transformer extends Task {
 		}
 		else {
 			// Target extents
-			if (getTarget().getBounds() != null) {			
+			if (getTarget().getBounds() != null) {
 				command.add("-te");
 				command.add(Double.toString(getTarget().getBounds().getXMin()));
 				command.add(Double.toString(getTarget().getBounds().getYMin()));
@@ -198,24 +198,24 @@ public class Transformer extends Task {
 		}
 
 		// Output file
-		command.add(target.getFileLocation().toString());	
+		command.add(target.getFileLocation().toString());
 
 		actionLog.add(StringUtils.join(command, " "));
 		try {
-			// If source is raster dataset							
+			// If source is raster dataset
 			// If source is vector dataset
-			commandUtil.start(command);			
+			commandUtil.start(command);
 		} catch (ProcessException | InterruptedException | IOException e) {
 			throw new TaskException(getDescription(), e);
-		} 
+		}
 	}
 
 	@Override
 	public void rollback() {
-		// Remove the transformed image from temporary storage		
+		// Remove the transformed image from temporary storage
 		if(target.deleteIfExists()) {
 			log.trace("Deleted {}", target);
-		}		
+		}
 	}
 
 	@Override
@@ -249,7 +249,7 @@ public class Transformer extends Task {
 	public void setSource(List<GraphicsFile> source) {
 		this.source = source;
 	}
-	
+
 	public List<GraphicsFile> getSource() {
 		return source;
 	}
@@ -260,8 +260,8 @@ public class Transformer extends Task {
 
 	public GraphicsFile getTarget() {
 		return target;
-	}	
-	
+	}
+
 	public Box getExtents() {
 		return extents;
 	}
@@ -271,9 +271,9 @@ public class Transformer extends Task {
 	}
 
 	public void addExtraOptions(List<String> args) {
-		// SKIP_NOSOURCE=YES/NO: Skip all processing for chunks for which there is no corresponding input data. 
-		// This will disable initializing the destination (INIT_DEST) and all other processing, and so should be used careful. 
-		// Mostly useful to short circuit a lot of extra work in mosaicing situations.		
+		// SKIP_NOSOURCE=YES/NO: Skip all processing for chunks for which there is no corresponding input data.
+		// This will disable initializing the destination (INIT_DEST) and all other processing, and so should be used careful.
+		// Mostly useful to short circuit a lot of extra work in mosaicing situations.
 
 		// NOTE: This needs to be disable for netCDF format, as on some cases this option create the below error.
 		// ERROR 1: netCDF scanline fetch failed: NetCDF: Operation not allowed in define mode
@@ -311,5 +311,5 @@ public class Transformer extends Task {
 
 	public void setDatatype(RasterDetails datatype) {
 		this.datatype = datatype;
-	}	
+	}
 }

--- a/src/storagemanager/src/main/java/org/vpac/ndg/task/Transformer.java
+++ b/src/storagemanager/src/main/java/org/vpac/ndg/task/Transformer.java
@@ -44,7 +44,7 @@ import org.vpac.ndg.storagemanager.GraphicsFile;
  * @author hsumanto
  *
  */
-public class Transformer extends Task {
+public class Transformer extends BaseTask {
 
 	final private Logger log = LoggerFactory.getLogger(Transformer.class);
 

--- a/src/storagemanager/src/main/java/org/vpac/ndg/task/Transformer.java
+++ b/src/storagemanager/src/main/java/org/vpac/ndg/task/Transformer.java
@@ -83,7 +83,7 @@ public class Transformer extends BaseTask {
 	}
 
 	@Override
-	public void execute(Collection<String> actionLog, IProgressCallback progressCallback) throws TaskException {
+	public void execute(Collection<String> actionLog, ProgressCallback progressCallback) throws TaskException {
 		if(isCheckSource()) {
 			if(getSource().isEmpty()) {
 				// During import if no input images then throws exception

--- a/src/storagemanager/src/main/java/org/vpac/ndg/task/Translator.java
+++ b/src/storagemanager/src/main/java/org/vpac/ndg/task/Translator.java
@@ -40,7 +40,7 @@ import org.vpac.ndg.storagemanager.GraphicsFile;
  * @author lachlan
  *
  */
-public class Translator extends Task {
+public class Translator extends BaseTask {
 
 	final private Logger log = LoggerFactory.getLogger(Translator.class);
 

--- a/src/storagemanager/src/main/java/org/vpac/ndg/task/Translator.java
+++ b/src/storagemanager/src/main/java/org/vpac/ndg/task/Translator.java
@@ -157,7 +157,7 @@ public class Translator extends BaseTask {
 	}
 
 	@Override
-	public void execute(Collection<String> actionLog, IProgressCallback progressCallback) throws TaskException {
+	public void execute(Collection<String> actionLog, ProgressCallback progressCallback) throws TaskException {
 		if(isCheckSource()) {
 			if(!getSource().exists()) {
 				// During import if no input image then throws exception

--- a/src/storagemanager/src/main/java/org/vpac/ndg/task/Translator.java
+++ b/src/storagemanager/src/main/java/org/vpac/ndg/task/Translator.java
@@ -112,13 +112,13 @@ public class Translator extends Task {
 		    command.add("-ot");
 		    command.add(outputType);
 		}
-		
+
 		//set the expand type
 		if (expand != null) {
 		    command.add("-expand");
 		    command.add(expand);
 		}
-		
+
 		// set the scale if specified
 		if (scale != null) {
 	        command.add("-scale");
@@ -127,7 +127,7 @@ public class Translator extends Task {
 	            log.info("value:" + d.get().toString());
 	        }
 		}
-		
+
 		// Add extra options such as Mosaicking options, Memory management options
 		addExtraOptions(command);
 
@@ -153,16 +153,16 @@ public class Translator extends Task {
 			log.error("Command failed: {}", e.getMessage());
 			log.error("Command was: {}", command);
 			throw new TaskException(getDescription(), e);
-		} 
+		}
 	}
 
 	@Override
-	public void execute(Collection<String> actionLog) throws TaskException {
+	public void execute(Collection<String> actionLog, IProgressCallback progressCallback) throws TaskException {
 		if(isCheckSource()) {
 			if(!getSource().exists()) {
 				// During import if no input image then throws exception
 				throw new TaskException(getDescription(), "Source file not exist:\n" + getSource().getFileLocation());
-			}	
+			}
 		}
 		else {
 			if(!getSource().exists()) {
@@ -230,10 +230,10 @@ public class Translator extends Task {
 	public void setTarget(GraphicsFile target) {
 		this.target = target;
 	}
-	
-	
-	
-	
+
+
+
+
 	public List<ScalarReceiver<Double>> getScale() {
         return scale;
     }
@@ -246,8 +246,8 @@ public class Translator extends Task {
         this.scale = scale;
     }
 
-    
-    
+
+
     public String getExpand() {
         return expand;
     }
@@ -263,9 +263,9 @@ public class Translator extends Task {
     public String getOutputType() {
         return outputType;
     }
-	
+
 	/**
-	 * sets the '-ot' argument passed to GDAL translate, must be one of 
+	 * sets the '-ot' argument passed to GDAL translate, must be one of
 	 * Byte/Int16/UInt16/UInt32/Int32/Float32/Float64/
      * CInt16/CInt32/CFloat32/CFloat64
 	 * @param outputType

--- a/src/storagemanager/src/main/java/org/vpac/ndg/task/VrtBuilder.java
+++ b/src/storagemanager/src/main/java/org/vpac/ndg/task/VrtBuilder.java
@@ -44,7 +44,7 @@ import org.vpac.ndg.storage.util.TimeSliceUtil;
 import org.vpac.ndg.storagemanager.GraphicsFile;
 import org.vpac.ndg.task.OutputDirStatistics;
 
-public class VrtBuilder extends Task {
+public class VrtBuilder extends BaseTask {
 
     final private Logger log = LoggerFactory.getLogger(VrtBuilder.class);
 

--- a/src/storagemanager/src/main/java/org/vpac/ndg/task/VrtBuilder.java
+++ b/src/storagemanager/src/main/java/org/vpac/ndg/task/VrtBuilder.java
@@ -212,7 +212,7 @@ public class VrtBuilder extends BaseTask {
 
 
     @Override
-    public void execute(Collection<String> actionLog, IProgressCallback progressCallback) throws TaskException {
+    public void execute(Collection<String> actionLog, ProgressCallback progressCallback) throws TaskException {
         if (source == null && sourceFile == null && source.isEmpty()) {
             // Can't work with zero input files. Just return; the output list
             // will not be populated. This is not an error.

--- a/src/storagemanager/src/main/java/org/vpac/ndg/task/VrtBuilder.java
+++ b/src/storagemanager/src/main/java/org/vpac/ndg/task/VrtBuilder.java
@@ -134,7 +134,7 @@ public class VrtBuilder extends Task {
         command.add("gdalbuildvrt");
 
         command.add("-overwrite");
-        
+
         if (targetResolutionSet) {
             command.add("-tr");
             command.add(Double.toString(targetResolutionX));
@@ -164,7 +164,7 @@ public class VrtBuilder extends Task {
                 if (os.getPixelType().get().equals("SIGNEDBYTE")) {
                     // Convert to byte value
                     // For example -1 nodata value not working for vrtbuilder
-                    // when output file's nodata type is byte and it's over 
+                    // when output file's nodata type is byte and it's over
                     // the boundary of byte, need to be convert
                     int nodataValue = srcNodata.byteValue() & 0xFF;
                     command.add(Integer.toString(nodataValue));
@@ -176,9 +176,9 @@ public class VrtBuilder extends Task {
                 command.add(os.getNodata().get().toString());
             }
         }
-        
+
         command.add(target.getFileLocation().toString());
-        
+
         if (source != null) {
             for (TileBand tileband : source) {
                 command.add(tileband.getFileLocation().toString());
@@ -209,10 +209,10 @@ public class VrtBuilder extends Task {
         }
         return sourceFiles;
     }
-    
-    
+
+
     @Override
-    public void execute(Collection<String> actionLog) throws TaskException {
+    public void execute(Collection<String> actionLog, IProgressCallback progressCallback) throws TaskException {
         if (source == null && sourceFile == null && source.isEmpty()) {
             // Can't work with zero input files. Just return; the output list
             // will not be populated. This is not an error.
@@ -294,7 +294,7 @@ public class VrtBuilder extends Task {
      * set the target resolution flag (-tr) passed to gdalbuildvrt, this will
      * prevent the '-resolution' arguement from being included in the command
      * line (obviously as the gdal docs state)
-     * 
+     *
      * @param resolutionX
      * @param resolutionY
      */
@@ -306,7 +306,7 @@ public class VrtBuilder extends Task {
 
     /**
      * set the target extents flag (-te) passed to gdalbuildvrt
-     * 
+     *
      * @param xmin
      * @param ymin
      * @param xmax
@@ -322,7 +322,7 @@ public class VrtBuilder extends Task {
     public void setSource(List<TileBand> source) {
         this.source = source;
     }
-    
+
     /**
      * Sets a graphics file as the source to use in the construction of a VRT file
      * @param source
@@ -361,7 +361,7 @@ public class VrtBuilder extends Task {
 
     /**
      * Set the temporary location for storing temporary .ncml file.
-     * 
+     *
      * @param temporaryLocation
      *            The specified temporary location.
      */

--- a/src/storagemanager/src/main/java/org/vpac/ndg/task/VrtColouriser.java
+++ b/src/storagemanager/src/main/java/org/vpac/ndg/task/VrtColouriser.java
@@ -83,7 +83,7 @@ public class VrtColouriser extends BaseTask {
     }
 
     @Override
-    public void execute(Collection<String> actionLog, IProgressCallback progressCallback) throws TaskException {
+    public void execute(Collection<String> actionLog, ProgressCallback progressCallback) throws TaskException {
         if (source == null) {
             // Can't work with zero input files. Just return; the output list
             // will not be populated. This is not an error.

--- a/src/storagemanager/src/main/java/org/vpac/ndg/task/VrtColouriser.java
+++ b/src/storagemanager/src/main/java/org/vpac/ndg/task/VrtColouriser.java
@@ -32,9 +32,9 @@ public class VrtColouriser extends Task {
 
     public static final int NUMBER_OF_COLOURS = 256;
     public static final String INSERT_BEFORE_DEFAULT = "<ColorInterp>";
-    
+
     private String insertBefore;
-    
+
     private GraphicsFile source;
     private GraphicsFile target;
     private Palette palette;
@@ -42,7 +42,7 @@ public class VrtColouriser extends Task {
     public VrtColouriser() {
         this("Adding Colour Table to VRT file");
     }
-    
+
     public VrtColouriser(String description) {
         super(description);
         this.insertBefore = INSERT_BEFORE_DEFAULT;
@@ -59,19 +59,19 @@ public class VrtColouriser extends Task {
             throw new TaskInitialisationException(getDescription(),
                     Constant.ERR_TARGET_DATASET_NOT_SPECIFIED);
         }
-        
+
         if (!getSource().getFileLocation().toFile().toString().endsWith(Constant.EXT_VRT)) {
             throw new TaskInitialisationException(getDescription(),
                     "Source must be a VRT file");
         }
-        
+
         if (!getTarget().getFileLocation().toFile().toString().endsWith(Constant.EXT_VRT)) {
             throw new TaskInitialisationException(getDescription(),
                     "Target must be a VRT file");
         }
 
     }
-    
+
     /**
      * tests weather the xml should be included at this line
      * @param line
@@ -81,16 +81,16 @@ public class VrtColouriser extends Task {
         String trimmed = line.trim();
         return trimmed.startsWith(insertBefore);
     }
-    
+
     @Override
-    public void execute(Collection<String> actionLog) throws TaskException {
+    public void execute(Collection<String> actionLog, IProgressCallback progressCallback) throws TaskException {
         if (source == null) {
             // Can't work with zero input files. Just return; the output list
             // will not be populated. This is not an error.
             log.debug("Source is empty; will not create a VRT.");
             return;
         }
-        
+
         //delete the target file if it exists (as we'll overwrite it anyway)
         if (target.getFileLocation().toFile().exists()) {
             actionLog.add(String.format("rm %s", target.getFileLocation()));
@@ -103,7 +103,7 @@ public class VrtColouriser extends Task {
         log.info("Using palette {}", palette);
 
         actionLog.add(String.format("Reading VRT from %s", source.getFileLocation()));
-        //Read all the lines in the source VRT file, this shouldn't be large 
+        //Read all the lines in the source VRT file, this shouldn't be large
         List<String> lines;
         try {
             lines = Files.readAllLines(source.getFileLocation(), Charset.defaultCharset());
@@ -118,7 +118,7 @@ public class VrtColouriser extends Task {
             File output = target.getFileLocation().toFile();
 
             writer = new BufferedWriter(new FileWriter(output));
-            
+
             //write each line of the source to the target, and add in some xml along the way...
             for (String line: lines) {
                 if (isInsertionPoint(line)) {
@@ -140,8 +140,8 @@ public class VrtColouriser extends Task {
             } catch (Exception e) {
             }
         }
-        
-        
+
+
 
     }
 
@@ -150,16 +150,16 @@ public class VrtColouriser extends Task {
      * @return
      */
     public String getColourTable() {
-        
+
         Color[] colours = getColours();
-        
+
         StringBuilder sb = new StringBuilder();
         sb.append("<ColorTable>" + System.lineSeparator());
-        
+
         for (Color c: colours) {
             sb.append("    " + colourToVrtXml(c) + System.lineSeparator());
         }
-        
+
         sb.append("</ColorTable>" + System.lineSeparator());
         //log.info("ColorTable:"+ sb.toString());
         return sb.toString();
@@ -183,14 +183,14 @@ public class VrtColouriser extends Task {
      * @return
      */
     private String colourToVrtXml(Color colour) {
-        
-        return String.format("<Entry c1=\"%d\" c2=\"%d\" c3=\"%d\" c4=\"%d\" />", 
-                             colour.getRed(), 
-                             colour.getGreen(), 
-                             colour.getBlue(), 
-                             colour.getAlpha());   
+
+        return String.format("<Entry c1=\"%d\" c2=\"%d\" c3=\"%d\" c4=\"%d\" />",
+                             colour.getRed(),
+                             colour.getGreen(),
+                             colour.getBlue(),
+                             colour.getAlpha());
     }
-    
+
     @Override
     public void rollback() {
         // nothing to do
@@ -242,18 +242,18 @@ public class VrtColouriser extends Task {
      * @param args
      */
     public static void main (String[] args) {
-        
+
         VrtColouriser colouriser = new VrtColouriser();
 
         colouriser.setPalette(NamedPalette.get("hash255", 1, 255));
         System.out.println(colouriser.getColourTable());
         System.out.println();
-        
+
         colouriser.setPalette(NamedPalette.get("rainbow240", 1, 255));
         System.out.println(colouriser.getColourTable());
         System.out.println();
-        
+
     }
-    
-    
+
+
 }

--- a/src/storagemanager/src/main/java/org/vpac/ndg/task/VrtColouriser.java
+++ b/src/storagemanager/src/main/java/org/vpac/ndg/task/VrtColouriser.java
@@ -26,7 +26,7 @@ import org.vpac.ndg.storagemanager.GraphicsFile;
  * @author lachlan
  *
  */
-public class VrtColouriser extends Task {
+public class VrtColouriser extends BaseTask {
 
     final private Logger log = LoggerFactory.getLogger(VrtColouriser.class);
 

--- a/src/storagemanager/src/main/java/org/vpac/ndg/task/WmtsQueryCreator.java
+++ b/src/storagemanager/src/main/java/org/vpac/ndg/task/WmtsQueryCreator.java
@@ -299,7 +299,7 @@ public class WmtsQueryCreator extends Application {
      * stop the task pipeline from deleting the output files automatically
      * @param t
      */
-    private void setTaskCleanupOptions(Task t) {
+    private void setTaskCleanupOptions(BaseTask t) {
         t.setCleanupSource(false);
         t.setCleanupTarget(false);
     }


### PR DESCRIPTION
This issue has been annoying me since we finished the LCM project. And now we have that big empty space waiting for the map to show up and a fancy new progress widget that we could reuse.

The progress is read from the stdout of gdal2tiles, it's actually pretty rich. All the code does is count the number of `.` characters output against how many in total are expected (62). That was the easy part.

There are 8 or so tasks in the wmts generation taskpipeline, some take half a second, some take half an hour. I've given all tasks a `progressWeight`, indicating how much they contribute to the overall progress. Without this the progress would race to 90%, then tick over ever so slightly to 100% as the map tiles are generated.

Unfortunately I had to modify the `ITask` interface to accept a progress callback, as there was no way for a task to communicate its progress back to its parent. Tasks do have a `JobProgress` attribute, I don't believe any of them use this (it was always null) and we should probably remove it.  Individual tasks should really only be reporting a simple value (say 0-100), and the `JobProgress` object is better suited to a `TaskPipeline`.

Atom ate all the spaces on blank lines (I have it set to auto delete them), and after lines of code. Sorry for the messy commit.
